### PR TITLE
Add DRF to Django apps

### DIFF
--- a/nfc_attendance/settings.py
+++ b/nfc_attendance/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    # Third-party apps
+    'rest_framework',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Summary
- install Django REST Framework in `INSTALLED_APPS`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686d8b5b03cc832cb49aebb04b60e5d2